### PR TITLE
Fix the dompdf entry point for wp-dependencies

### DIFF
--- a/voce-post-pdfs.php
+++ b/voce-post-pdfs.php
@@ -1,6 +1,6 @@
 <?php
 
-use Dompdf\DOMPDF;
+use Dompdf\Dompdf;
 
 if( file_exists( __DIR__ . '/vendor/autoload.php' ) ){
 	require_once  __DIR__ . '/vendor/autoload.php';
@@ -181,7 +181,7 @@ class Voce_Post_PDFS {
 
 		do_action( 'wp_load_dependency', 'dompdf/dompdf', 'src/Autoloader.php' );
 		// generate the pdf
-		$dompdf = new DOMPDF();
+		$dompdf = new Dompdf();
 		$dompdf->load_html( $content );
 		$dompdf->set_paper( 'letter', 'portrait' );
 		$dompdf->render();

--- a/voce-post-pdfs.php
+++ b/voce-post-pdfs.php
@@ -179,7 +179,7 @@ class Voce_Post_PDFS {
 
 		require_once __DIR__ . '/dompdf_config.custom.inc.php';
 
-		do_action( 'wp_load_dependency', 'dompdf/dompdf', 'dompdf_config.inc.php' );
+		do_action( 'wp_load_dependency', 'dompdf/dompdf', 'src/Autoloader.php' );
 		// generate the pdf
 		$dompdf = new DOMPDF();
 		$dompdf->load_html( $content );


### PR DESCRIPTION
Last PR (#1) I updated dompdf to the latest version, but didn't update the entry filename used here in this `wp_load_dependency` call. It was working locally for me because I was using composer autoloading, but not working on deployment.

This commit fixes the path to the plugin entry so that it will work on hosting.